### PR TITLE
Access document within onMount to allow SSR without document dependency

### DIFF
--- a/src/NumberSpinner.svelte
+++ b/src/NumberSpinner.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { onMount } from 'svelte';
   import { createEventDispatcher, tick } from "svelte";
   const dispatch = createEventDispatcher();
 
@@ -45,9 +46,14 @@
   let editing = false;
 
   let style;
-  let htmlNode = document.querySelector("html");
-  let htmlNodeOriginalCursor = htmlNode.style.cursor;
+  let htmlNode = null;
+  let htmlNodeOriginalCursor = null;
   let defaultCursor;
+
+  onMount(() => {
+    htmlNode = document.querySelector("html");
+    htmlNodeOriginalCursor = htmlNode.style.cursor;
+  });
 
   // update all values (preciseValue, visibleValue)
   updateValues(value);
@@ -225,12 +231,14 @@
 
     defaultCursor = horizontal ? (vertical ? "move" : "ew-resize") : "ns-resize";
 
-    if (dragging) {
-      htmlNode.style.cursor = cursor ?? defaultCursor;
-      // addClass(htmlNode, cursorClass);
-    } else {
-      htmlNode.style.cursor = htmlNodeOriginalCursor;
-      // removeClass(htmlNode, cursorClass);
+    if (htmlNode) {
+      if (dragging) {
+        htmlNode.style.cursor = cursor ?? defaultCursor;
+        // addClass(htmlNode, cursorClass);
+      } else {
+        htmlNode.style.cursor = htmlNodeOriginalCursor;
+        // removeClass(htmlNode, cursorClass);
+      }
     }
   }
 


### PR DESCRIPTION
Hello Hartmut!

I really appreciate your work at this component. Maybe you're inspired by Bret Victor, too, or maybe you've seen this kind of Number Spinner component somewhere else? I remember some Adobe tools having this kind of controls as well.

When I tried to use your component in my SvelteKit project, I've got these error messages:
```
document is not defined
ReferenceError: document is not defined
    at NumberSpinner.svelte:45:25
    at Object.$$render (/Users/d433890/Desktop/Matthias/matths-web/node_modules/svelte/internal/index.js:1677:22)
    at styled-number-spinner.svelte:10:21
    at Object.$$render (/Users/d433890/Desktop/Matthias/matths-web/node_modules/svelte/internal/index.js:1677:22)
    at eval (/src/lib/components/tomato.svelte:48:98)
    at Object.$$render (/Users/d433890/Desktop/Matthias/matths-web/node_modules/svelte/internal/index.js:1677:22)
    at Object.default (/Users/d433890/Desktop/Matthias/matths-web/src/routes/posts/draw-tomatoes.md:26:85)
    at eval (/src/routes/posts/_layout.svelte:45:32)
    at Object.$$render (/Users/d433890/Desktop/Matthias/matths-web/node_modules/svelte/internal/index.js:1677:22)
    at draw-tomatoes.md:9:27
```

The reason is, that SvelteKit can't apply SSR, because when rendering components at the server, there's no `document`. So the component has to initialize this as soon as it was rendered. For that, there's the onMount callback.

Maybe you want to have a look at my changes.
Cheers, Matthias